### PR TITLE
Update to SP11, replacement of showModalDialog

### DIFF
--- a/Imports/RefreshFromDatabase/Import/Method/Refresh from Database.xml
+++ b/Imports/RefreshFromDatabase/Import/Method/Refresh from Database.xml
@@ -7,54 +7,59 @@ var doc = parent.frames[1].document;
 
 if (doc)
 {
+    var generation = function(){
+        // Get the most recent generation of the currently opened item
+        var itemID = doc.itemID;
+        var itemType = doc.thisItem.getType();
+
+        var oldPart = inn.newItem(itemType, "get");
+        oldPart.setID(itemID);
+        oldPart = oldPart.apply();
+
+        var newPart = inn.newItem(itemType, "get");
+        newPart.setProperty("config_id", oldPart.getProperty("config_id"));
+        newPart.setProperty("is_current", "1");
+        newPart = newPart.apply();
+
+        // Show the newest generation of this item in the same tearoff window or tab
+        doc.thisItem = newPart;
+        aras.uiReShowItemEx(oldPart.getID(), doc.thisItem.node);
+    }
+
     // Make sure that any changes will not be overwritten unintentionally
-    if (top.aras.isDirtyEx(doc.thisItem.node))
+    if (aras.isDirtyEx(doc.thisItem.node))
     {
-        var options = {dialogWidth: 400, dialogHeight: 200, center: true},
-            params = {
-                aras: top.aras,
+        var params = {
+                aras: aras,
+                dialogWidth: 400, 
+                dialogHeight: 200,
                 message: "Refreshing from the database will overwrite your changes. Do you wish to continue?",
                 buttons: {
-                    btnYes: top.aras.getResource('', 'common.yes'),
-                    btnCancel: top.aras.getResource('', 'common.cancel')
+                    btnYes: aras.getResource('', 'common.yes'),
+                    btnCancel: aras.getResource('', 'common.cancel')
                 },
-                defaultButton: 'btnCancel'
-            },
-            returnedValue;
-        
-    	var wnd = top.aras.getMainWindow();
-    	wnd = wnd === top ? wnd.main : top;
-        if (wnd.showModalDialog) {
-            returnedValue = top.aras.modalDialogHelper.show('DefaultModal', wnd, params, options, 'groupChgsDialog.html');
-        } else {
-            returnedValue = 'btnCancel';
-            if (window.confirm("Refreshing from the database will overwrite your changes. Do you wish to continue?")) {
-                returnedValue = 'btnYes;'
+                defaultButton: 'btnCancel',
+                content: 'groupChgsDialog.html'
             }
-        }
-        
-        if (returnedValue == 'btnCancel')
-        {
-            return null;
-        }
+        var returnedValue;
+
+	var wnd = aras.getMostTopWindowWithAras(window);
+        wnd = wnd.main || wnd;
+        wnd.ArasModules.Dialog.show('iframe', params).promise.then(function(returnedValue) {
+            //if (window.confirm("Refreshing from the database will overwrite your changes. Do you wish to continue?")) {
+            //    returnedValue = 'btnYes;'
+            //}
+
+            if (returnedValue == 'btnCancel')
+            {
+                return null;
+            }
+            generation();
+
+        }.bind(this));
+    } else {
+        generation();
     }
-    
-    // Get the most recent generation of the currently opened item
-    var itemID = doc.itemID;
-    var itemType = doc.thisItem.getType();
-    
-    var oldPart = inn.newItem(itemType, "get");
-    oldPart.setID(itemID);
-    oldPart = oldPart.apply();
-    
-    var newPart = inn.newItem(itemType, "get");
-    newPart.setProperty("config_id", oldPart.getProperty("config_id"));
-    newPart.setProperty("is_current", "1");
-    newPart = newPart.apply();
-    
-    // Show the newest generation of this item in the same tearoff window or tab
-    doc.thisItem = newPart;
-    top.aras.uiReShowItemEx(oldPart.getID(), doc.thisItem.node);
 }
 ]]></method_code>
   <method_type>JavaScript</method_type>


### PR DESCRIPTION
Previous version can cause error messages in SP11, especially when calling Method from superseded Items.